### PR TITLE
feat: add login and protected routes with lazy loading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,15 @@
 // src/App.jsx
 import React from "react";
 import { Outlet, Link } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { logout } from "./store/authSlice";
 
 export default function App() {
+  const dispatch = useDispatch();
+  const isAuthenticated = useSelector((s) => s.auth.isAuthenticated);
+
+  const handleLogout = () => dispatch(logout());
+
   return (
     <div>
       {/* Navbar global */}
@@ -15,11 +22,21 @@ export default function App() {
                 <Link className="nav-link" to="/">Historias</Link>
               </li>
               <li className="nav-item">
-                <Link className="nav-link" to="/initiatives-overview">Iniciativas</Link>
+                <Link className="nav-link" to="/initiatives">Iniciativas</Link>
               </li>
-              <li className="nav-item">
-                <Link className="nav-link" to="/login">Login</Link>
-              </li>
+              {isAuthenticated ? (
+                <li className="nav-item">
+                  <button className="nav-link btn btn-link" onClick={handleLogout}>
+                    Logout
+                  </button>
+                </li>
+              ) : (
+                <li className="nav-item">
+                  <Link className="nav-link" to="/login">
+                    Login
+                  </Link>
+                </li>
+              )}
             </ul>
           </div>
         </div>

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -2,10 +2,10 @@
 import React, { Suspense, lazy } from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import App from "./App";
+import ProtectedRoute from "./components/ProtectedRoute";
 
 const HUTrackerPage = lazy(() => import("./pages/HUTrackerPage"));
 const InitiativesOverviewPage = lazy(() => import("./pages/InitiativesOverviewPage"));
-const InitiativeDetailPage = lazy(() => import("./pages/InitiativeDetailPage"));
 const LoginPage = lazy(() => import("./pages/LoginPage"));
 
 const router = createBrowserRouter([
@@ -13,16 +13,23 @@ const router = createBrowserRouter([
     path: "/",
     element: <App />,
     children: [
-      { path: "/", element: <InitiativesOverviewPage /> },
-      { path: "/initiatives", element: <InitiativesOverviewPage /> },
-      { path: "/initiatives/:id", element: <HUTrackerPage /> },
       { path: "/login", element: <LoginPage /> },
+      {
+        element: <ProtectedRoute />,
+        children: [
+          { index: true, element: <InitiativesOverviewPage /> },
+          { path: "initiatives", element: <InitiativesOverviewPage /> },
+          { path: "initiatives/:id", element: <HUTrackerPage /> },
+        ],
+      },
     ],
   },
 ]);
 
 export default function AppRouter() {
   return (
-    <RouterProvider router={router} />
+    <Suspense fallback={<div>Loading...</div>}>
+      <RouterProvider router={router} />
+    </Suspense>
   );
 }

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,9 @@
+// src/components/ProtectedRoute.jsx
+import React from "react";
+import { useSelector } from "react-redux";
+import { Navigate, Outlet } from "react-router-dom";
+
+export default function ProtectedRoute() {
+  const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);
+  return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />;
+}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,22 +1,54 @@
 // src/pages/LoginPage.jsx
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { login } from "../store/authSlice";
 
 export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // Aquí podrías validar credenciales contra un backend
+    if (email && password) {
+      dispatch(login());
+      navigate("/", { replace: true });
+    }
+  };
+
   return (
     <div className="container py-5" style={{ maxWidth: 420 }}>
       <h3 className="mb-4">Login</h3>
       <div className="card shadow-sm">
         <div className="card-body">
-          <div className="mb-3">
-            <label className="form-label">Email</label>
-            <input className="form-control" type="email" placeholder="you@company.com" />
-          </div>
-          <div className="mb-3">
-            <label className="form-label">Password</label>
-            <input className="form-control" type="password" placeholder="••••••••" />
-          </div>
-          <button className="btn btn-primary w-100">Entrar</button>
+          <form onSubmit={handleSubmit}>
+            <div className="mb-3">
+              <label className="form-label">Email</label>
+              <input
+                className="form-control"
+                type="email"
+                placeholder="you@company.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <div className="mb-3">
+              <label className="form-label">Password</label>
+              <input
+                className="form-control"
+                type="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+            <button className="btn btn-primary w-100" type="submit">
+              Entrar
+            </button>
+          </form>
           <div className="text-center mt-3">
             <Link to="/">Volver</Link>
           </div>

--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -1,0 +1,22 @@
+// src/store/authSlice.js
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  isAuthenticated: false,
+};
+
+export const authSlice = createSlice({
+  name: "auth",
+  initialState,
+  reducers: {
+    login: (state) => {
+      state.isAuthenticated = true;
+    },
+    logout: (state) => {
+      state.isAuthenticated = false;
+    },
+  },
+});
+
+export const { login, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,9 +1,11 @@
 // src/store/index.js
 import { configureStore } from "@reduxjs/toolkit";
 import huReducer from "./huSlice";
+import authReducer from "./authSlice";
 
 export const store = configureStore({
   reducer: {
     hu: huReducer,
+    auth: authReducer,
   },
 });


### PR DESCRIPTION
## Summary
- add Redux auth slice and ProtectedRoute
- lazy-load pages and guard routes behind login
- implement login page and navbar logout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React Hooks must be called in same order; no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c435fad8bc8331812b795a4b5773ec