### PR TITLE
feat: add login and protected routes with sprint burndown chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <title>HU Tracker</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,19 @@
 // src/App.jsx
 import React from "react";
 import { Outlet, Link } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { logout } from "./store/authSlice";
 
 export default function App() {
+  const dispatch = useDispatch();
+  const isAuthenticated = useSelector((s) => s.auth.isAuthenticated);
+
+  const handleLogout = () => dispatch(logout());
+
   return (
-    <div>
+    <div className="d-flex flex-column min-vh-100">
       {/* Navbar global */}
-      <nav className="navbar navbar-expand-lg navbar-dark bg-dark">
+      <nav className="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
         <div className="container-fluid">
           <Link className="navbar-brand" to="/">HU Tracker</Link>
           <div className="collapse navbar-collapse">
@@ -15,18 +22,28 @@ export default function App() {
                 <Link className="nav-link" to="/">Historias</Link>
               </li>
               <li className="nav-item">
-                <Link className="nav-link" to="/initiatives-overview">Iniciativas</Link>
+                <Link className="nav-link" to="/initiatives">Iniciativas</Link>
               </li>
-              <li className="nav-item">
-                <Link className="nav-link" to="/login">Login</Link>
-              </li>
+              {isAuthenticated ? (
+                <li className="nav-item">
+                  <button className="nav-link btn btn-link" onClick={handleLogout}>
+                    Logout
+                  </button>
+                </li>
+              ) : (
+                <li className="nav-item">
+                  <Link className="nav-link" to="/login">
+                    Login
+                  </Link>
+                </li>
+              )}
             </ul>
           </div>
         </div>
       </nav>
 
       {/* Aquí se renderizan las páginas */}
-      <main className="container py-4">
+      <main className="container py-4 flex-grow-1">
         <Outlet />
       </main>
     </div>

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -2,10 +2,10 @@
 import React, { Suspense, lazy } from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import App from "./App";
+import ProtectedRoute from "./components/ProtectedRoute";
 
 const HUTrackerPage = lazy(() => import("./pages/HUTrackerPage"));
 const InitiativesOverviewPage = lazy(() => import("./pages/InitiativesOverviewPage"));
-const InitiativeDetailPage = lazy(() => import("./pages/InitiativeDetailPage"));
 const LoginPage = lazy(() => import("./pages/LoginPage"));
 
 const router = createBrowserRouter([
@@ -13,16 +13,23 @@ const router = createBrowserRouter([
     path: "/",
     element: <App />,
     children: [
-      { path: "/", element: <InitiativesOverviewPage /> },
-      { path: "/initiatives", element: <InitiativesOverviewPage /> },
-      { path: "/initiatives/:id", element: <HUTrackerPage /> },
       { path: "/login", element: <LoginPage /> },
+      {
+        element: <ProtectedRoute />,
+        children: [
+          { index: true, element: <InitiativesOverviewPage /> },
+          { path: "initiatives", element: <InitiativesOverviewPage /> },
+          { path: "initiatives/:id", element: <HUTrackerPage /> },
+        ],
+      },
     ],
   },
 ]);
 
 export default function AppRouter() {
   return (
-    <RouterProvider router={router} />
+    <Suspense fallback={<div>Loading...</div>}>
+      <RouterProvider router={router} />
+    </Suspense>
   );
 }

--- a/src/components/BurndownChart.jsx
+++ b/src/components/BurndownChart.jsx
@@ -12,12 +12,12 @@ import {
 } from "recharts";
 
 export default function BurndownChart({ burndownData, initiative }) {
-  if (!burndownData || burndownData.length === 0) return null;
+  const data = useMemo(() => burndownData || [], [burndownData]);
 
   // Escala Y consistente para las barras (horas)
   const yMaxHours = useMemo(() => {
     let max = 0;
-    for (const d of burndownData) {
+    for (const d of data) {
       const stacked =
         (Number(d.CompletedHours) || 0) +
         (Number(d.RemainingHours) || 0) +
@@ -25,16 +25,18 @@ export default function BurndownChart({ burndownData, initiative }) {
       max = Math.max(max, stacked, Number(d.CapacityHoursUntilDue) || 0);
     }
     return Math.ceil(max * 1.1); // +10% de aire
-  }, [burndownData]);
+  }, [data]);
 
   // Escala Y para días
   const yMaxDays = useMemo(() => {
     let max = 0;
-    for (const d of burndownData) {
+    for (const d of data) {
       max = Math.max(max, Number(d.CapacityDaysUntilDue) || 0);
     }
     return Math.ceil(max * 1.1);
-  }, [burndownData]);
+  }, [data]);
+
+  if (data.length === 0) return null;
 
   return (
     <div className="card shadow-sm mt-4">
@@ -43,7 +45,7 @@ export default function BurndownChart({ burndownData, initiative }) {
           Avance por HU — {initiative || "General"}
         </h5>
         <ResponsiveContainer width="100%" height={420}>
-          <BarChart data={burndownData}>
+          <BarChart data={data}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="Title" />
 

--- a/src/components/HUTable.jsx
+++ b/src/components/HUTable.jsx
@@ -66,14 +66,6 @@ export default function HUTable({
             </thead>
             <tbody>
               {data.map((row, idx) => {
-                const start = row["Start Date"]
-                  ? new Date(row["Start Date"])
-                  : new Date();
-                const due = row["Due Date"]
-                  ? new Date(row["Due Date"])
-                  : new Date();
-                const today = new Date();
-
                 const { elapsedDays, delayHours, delayDays } =
                   calculateElapsedAndDelay(
                     new Date(row["Start Date"]),

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,9 @@
+// src/components/ProtectedRoute.jsx
+import React from "react";
+import { useSelector } from "react-redux";
+import { Navigate, Outlet } from "react-router-dom";
+
+export default function ProtectedRoute() {
+  const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);
+  return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />;
+}

--- a/src/components/SprintBurndownChart.jsx
+++ b/src/components/SprintBurndownChart.jsx
@@ -1,0 +1,90 @@
+import React, { useMemo } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { businessDaysBetween } from "../utils/timeCalculations";
+
+function addBusinessDays(start, days) {
+  const date = new Date(start);
+  let added = 0;
+  while (added < days) {
+    date.setDate(date.getDate() + 1);
+    const day = date.getDay();
+    if (day !== 0 && day !== 6) {
+      added++;
+    }
+  }
+  return date;
+}
+
+export default function SprintBurndownChart({ tasks }) {
+  const { points, delay } = useMemo(() => {
+    if (!tasks || tasks.length === 0) return { points: [], delay: 0 };
+
+    const parsed = tasks.map((t) => ({
+      start: t["Start Date"] ? new Date(t["Start Date"]) : new Date(),
+      due: t["Due Date"] ? new Date(t["Due Date"]) : new Date(),
+      original: Number(t["Original Estimate"]) || 0,
+      completed: Number(t["Completed Work"]) || 0,
+    }));
+
+    const startDate = parsed.reduce((min, t) => (t.start < min ? t.start : min), parsed[0].start);
+    const dueDate = parsed.reduce((max, t) => (t.due > max ? t.due : max), parsed[0].due);
+    const totalOriginal = parsed.reduce((sum, t) => sum + t.original, 0);
+    const totalCompleted = parsed.reduce((sum, t) => sum + t.completed, 0);
+
+    const totalDays = Math.max(1, businessDaysBetween(startDate, dueDate));
+    const today = new Date();
+    const daysElapsed = Math.min(businessDaysBetween(startDate, today), totalDays);
+    const burnRate = daysElapsed > 0 ? totalCompleted / daysElapsed : 0;
+    const remaining = Math.max(totalOriginal - totalCompleted, 0);
+    const projectedDays = burnRate > 0 ? Math.ceil(remaining / burnRate) : 0;
+    const projectedTotalDays = daysElapsed + projectedDays;
+    const maxDays = Math.max(totalDays, projectedTotalDays);
+
+    const pts = [];
+    for (let i = 0; i <= maxDays; i++) {
+      const date = addBusinessDays(startDate, i);
+      const ideal = i <= totalDays ? totalOriginal - (totalOriginal / totalDays) * i : null;
+      const projected = burnRate > 0 ? Math.max(totalOriginal - burnRate * i, 0) : null;
+      pts.push({ day: date.toLocaleDateString(), ideal, projected });
+    }
+
+    const delayDays = Math.max(0, projectedTotalDays - totalDays);
+    return { points: pts, delay: delayDays };
+  }, [tasks]);
+
+  if (!points.length) return null;
+
+  return (
+    <div className="card shadow-sm mt-4">
+      <div className="card-body">
+        <h5 className="card-title mb-3">Burndown Chart</h5>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={points}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="day" />
+            <YAxis allowDecimals={false} />
+            <Tooltip />
+            <Legend />
+            <Line type="monotone" dataKey="ideal" stroke="#0d6efd" name="Ideal Burndown" />
+            <Line type="monotone" dataKey="projected" stroke="#dc3545" name="Projected Burndown" />
+          </LineChart>
+        </ResponsiveContainer>
+        {delay > 0 && (
+          <p className="text-danger fw-bold mt-2">
+            Projected Delay: {delay} day(s)
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,19 @@
+/* Global theme for a modern management look */
+body {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background-color: #f5f7fa;
+  color: #212529;
+}
+
+.navbar {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.card {
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
 /* Colores del SELECT por estado (evita duplicados visuales) */
 .status-select--todo {
   background-color: #e9ecef;   /* gris claro */

--- a/src/pages/HUTrackerPage.jsx
+++ b/src/pages/HUTrackerPage.jsx
@@ -11,11 +11,8 @@ import {
 import HUForm from "../components/HUForm";
 import HUTable from "../components/HUTable";
 import BurndownChart from "../components/BurndownChart";
-import {
-  WORK_HOURS_PER_DAY,
-  businessDaysBetween,
-  calculateElapsedAndDelay,
-} from "../utils/timeCalculations";
+import SprintBurndownChart from "../components/SprintBurndownChart";
+import { WORK_HOURS_PER_DAY, calculateElapsedAndDelay } from "../utils/timeCalculations";
 import { useParams, Link } from "react-router-dom";
 import { initiativesMock } from "../mocks/initiativesMock";
 
@@ -113,7 +110,6 @@ export default function HUTrackerPage() {
       const today = new Date();
 
       const {
-        elapsedDays,
         delayHours,
         delayDays,
         capacityHoursUntilDue,
@@ -219,7 +215,10 @@ export default function HUTrackerPage() {
         onDelete={onDeleteHU}
       />
 
-      {/* Chart */}
+      {/* Sprint Burndown */}
+      <SprintBurndownChart tasks={sprintFiltered} />
+
+      {/* Detalle por HU */}
       <BurndownChart
         burndownData={burndownData}
         initiative={selectedInitiative}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,22 +1,54 @@
 // src/pages/LoginPage.jsx
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { login } from "../store/authSlice";
 
 export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // Aquí podrías validar credenciales contra un backend
+    if (email && password) {
+      dispatch(login());
+      navigate("/", { replace: true });
+    }
+  };
+
   return (
-    <div className="container py-5" style={{ maxWidth: 420 }}>
-      <h3 className="mb-4">Login</h3>
-      <div className="card shadow-sm">
-        <div className="card-body">
-          <div className="mb-3">
-            <label className="form-label">Email</label>
-            <input className="form-control" type="email" placeholder="you@company.com" />
-          </div>
-          <div className="mb-3">
-            <label className="form-label">Password</label>
-            <input className="form-control" type="password" placeholder="••••••••" />
-          </div>
-          <button className="btn btn-primary w-100">Entrar</button>
+    <div className="d-flex align-items-center justify-content-center min-vh-100">
+      <div className="w-100" style={{ maxWidth: 420 }}>
+        <div className="card p-4 shadow-sm">
+          <h3 className="mb-4 text-center">Login</h3>
+          <form onSubmit={handleSubmit}>
+            <div className="mb-3">
+              <label className="form-label">Email</label>
+              <input
+                className="form-control"
+                type="email"
+                placeholder="you@company.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <div className="mb-3">
+              <label className="form-label">Password</label>
+              <input
+                className="form-control"
+                type="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+            <button className="btn btn-primary w-100" type="submit">
+              Entrar
+            </button>
+          </form>
           <div className="text-center mt-3">
             <Link to="/">Volver</Link>
           </div>

--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -1,0 +1,22 @@
+// src/store/authSlice.js
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  isAuthenticated: false,
+};
+
+export const authSlice = createSlice({
+  name: "auth",
+  initialState,
+  reducers: {
+    login: (state) => {
+      state.isAuthenticated = true;
+    },
+    logout: (state) => {
+      state.isAuthenticated = false;
+    },
+  },
+});
+
+export const { login, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,9 +1,11 @@
 // src/store/index.js
 import { configureStore } from "@reduxjs/toolkit";
 import huReducer from "./huSlice";
+import authReducer from "./authSlice";
 
 export const store = configureStore({
   reducer: {
     hu: huReducer,
+    auth: authReducer,
   },
 });


### PR DESCRIPTION
## Summary
- add Redux auth slice and ProtectedRoute
- lazy-load pages and guard routes behind login
- implement login page and navbar logout
- add sprint burndown chart with ideal vs projected burn
- modernize global theme with Inter font, light navbar, and centered login layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c435fad8bc8331812b795a4b5773ec