### PR TITLE
Enable sprint working days and dark theme

### DIFF
--- a/src/components/HUTable.jsx
+++ b/src/components/HUTable.jsx
@@ -66,11 +66,21 @@ export default function HUTable({
             </thead>
             <tbody>
               {data.map((row, idx) => {
+                const effectiveToday =
+                  row.State === "Done" &&
+                  Number(row["Completed Work"]) >=
+                    Number(row["Original Estimate"])
+                    ? new Date(
+                        row["Completion Date"] ||
+                          row["Due Date"] ||
+                          row["Start Date"]
+                      )
+                    : new Date();
                 const { elapsedDays, delayHours, delayDays } =
                   calculateElapsedAndDelay(
                     new Date(row["Start Date"]),
-                    new Date(row["Due Date"]),
-                    new Date(),
+                    new Date(row["Completion Date"] || row["Due Date"]),
+                    effectiveToday,
                     Number(row["Original Estimate"]) || 0,
                     Number(row["Completed Work"]) || 0
                   );

--- a/src/components/SprintBurndownChart.jsx
+++ b/src/components/SprintBurndownChart.jsx
@@ -24,7 +24,7 @@ function addBusinessDays(start, days) {
   return date;
 }
 
-export default function SprintBurndownChart({ tasks }) {
+export default function SprintBurndownChart({ tasks, sprintDays }) {
   const { points, delay } = useMemo(() => {
     if (!tasks || tasks.length === 0) return { points: [], delay: 0 };
 
@@ -45,8 +45,11 @@ export default function SprintBurndownChart({ tasks }) {
     );
     const totalOriginal = parsed.reduce((sum, t) => sum + t.original, 0);
     const totalCompleted = parsed.reduce((sum, t) => sum + t.completed, 0);
-
-    const totalDays = Math.max(1, businessDaysBetween(startDate, dueDate) - 1);
+    const fallbackTotal = Math.max(
+      1,
+      businessDaysBetween(startDate, dueDate) - 1
+    );
+    const totalDays = sprintDays || fallbackTotal;
     const today = new Date();
     const daysElapsed = Math.max(
       0,
@@ -72,7 +75,7 @@ export default function SprintBurndownChart({ tasks }) {
 
     const delayDays = Math.max(0, projectedTotalDays - totalDays);
     return { points: pts, delay: delayDays };
-  }, [tasks]);
+  }, [tasks, sprintDays]);
 
   if (!points.length) return null;
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,17 +1,37 @@
 /* Global theme for a modern management look */
 body {
   font-family: "Inter", system-ui, -apple-system, sans-serif;
-  background-color: #f5f7fa;
-  color: #212529;
+  background-color: #121212;
+  color: #eaeaea;
 }
 
 .navbar {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid #2c2c2c;
 }
 
 .card {
   border-radius: 0.5rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  background-color: #1e1e1e;
+  border: 1px solid #2c2c2c;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 4px 8px rgba(255, 255, 255, 0.1);
+}
+
+table.table {
+  color: #eaeaea;
+}
+
+table.table thead th {
+  background-color: #2c2c2c;
+  color: #eaeaea;
+}
+
+table.table tbody tr:hover {
+  background-color: #333333;
 }
 
 /* Colores del SELECT por estado (evita duplicados visuales) */

--- a/src/mocks/initiativesMock.js
+++ b/src/mocks/initiativesMock.js
@@ -5,6 +5,7 @@ export const initiativesMock = [
     name: "Ecommerce Platform",
     startDate: "2025-09-01",
     dueDate: "2025-09-15",
+    sprintDays: 10,
     stories: [
       {
         id: "hu-1",
@@ -33,6 +34,7 @@ export const initiativesMock = [
     name: "Analytics Dashboard",
     startDate: "2025-09-05",
     dueDate: "2025-09-20",
+    sprintDays: 15,
     stories: [
       {
         id: "hu-3",

--- a/src/pages/HUTrackerPage.jsx
+++ b/src/pages/HUTrackerPage.jsx
@@ -19,7 +19,7 @@ import { initiativesMock } from "../mocks/initiativesMock";
 export default function HUTrackerPage() {
   const { id } = useParams(); // initiative id
   const dispatch = useDispatch();
-  const { items, selectedInitiative } = useSelector((s) => s.hu);
+  const { items, selectedInitiative, initiatives } = useSelector((s) => s.hu);
 
   const [newHU, setNewHU] = useState({
     Title: "",
@@ -94,6 +94,11 @@ export default function HUTrackerPage() {
     if (selectedSprint === "General") return filtered;
     return filtered.filter((hu) => hu.Sprint === selectedSprint);
   }, [filtered, selectedSprint]);
+
+  const currentInitiative = useMemo(
+    () => initiatives.find((i) => i.name === selectedInitiative),
+    [initiatives, selectedInitiative]
+  );
 
   // build burndown dataset
 
@@ -216,7 +221,10 @@ export default function HUTrackerPage() {
       />
 
       {/* Sprint Burndown */}
-      <SprintBurndownChart tasks={sprintFiltered} />
+      <SprintBurndownChart
+        tasks={sprintFiltered}
+        sprintDays={currentInitiative?.sprintDays}
+      />
 
       {/* Detalle por HU */}
       <BurndownChart

--- a/src/pages/InitiativesOverviewPage.jsx
+++ b/src/pages/InitiativesOverviewPage.jsx
@@ -30,6 +30,7 @@ export default function InitiativesOverviewPage() {
     name: "",
     startDate: "",
     dueDate: "",
+    sprintDays: 10,
   });
 
   const summary = useMemo(() => {
@@ -95,9 +96,16 @@ export default function InitiativesOverviewPage() {
       ...newIni,
       id: `ini-${Date.now()}`,
       stories: [],
+      sprintDays: Number(newIni.sprintDays) || 10,
     };
     dispatch(addInitiative(iniToAdd));
-    setNewIni({ id: "", name: "", startDate: "", dueDate: "" });
+    setNewIni({
+      id: "",
+      name: "",
+      startDate: "",
+      dueDate: "",
+      sprintDays: 10,
+    });
   };
 
   const handleEditById = (id, key, value) => {
@@ -119,7 +127,7 @@ export default function InitiativesOverviewPage() {
         <div className="card-body">
           <h5 className="card-title mb-3">Agregar Nueva Iniciativa</h5>
           <div className="row g-2">
-            <div className="col-md-4">
+            <div className="col-md-3">
               <input
                 type="text"
                 className="form-control"
@@ -145,6 +153,17 @@ export default function InitiativesOverviewPage() {
               />
             </div>
             <div className="col-md-2">
+              <input
+                type="number"
+                className="form-control"
+                placeholder="Días sprint"
+                value={newIni.sprintDays}
+                onChange={(e) =>
+                  setNewIni({ ...newIni, sprintDays: e.target.value })
+                }
+              />
+            </div>
+            <div className="col-md-1">
               <button className="btn btn-primary w-100" onClick={handleAddInitiative}>
                 Agregar
               </button>
@@ -168,6 +187,7 @@ export default function InitiativesOverviewPage() {
             <th>Initiative</th>
             <th>Start Date</th>
             <th>Due Date</th>
+            <th>Sprint Days</th>
             <th>Historias</th>
             <th>Original (hrs)</th>
             <th>Completed (hrs)</th>
@@ -210,6 +230,16 @@ export default function InitiativesOverviewPage() {
                   }
                 />
               </td>
+              <td>
+                <input
+                  type="number"
+                  className="form-control form-control-sm"
+                  value={row.sprintDays || ""}
+                  onChange={(e) =>
+                    handleEditById(row.id, "sprintDays", e.target.value)
+                  }
+                />
+              </td>
               <td>{row.totalHU}</td>
               <td>{row.original}</td>
               <td>{row.completed}</td>
@@ -240,7 +270,7 @@ export default function InitiativesOverviewPage() {
           ))}
           {summary.length === 0 && (
             <tr>
-              <td colSpan="10" className="text-center text-muted">
+              <td colSpan="11" className="text-center text-muted">
                 No hay iniciativas, agrega una arriba.
               </td>
             </tr>

--- a/src/store/huSlice.js
+++ b/src/store/huSlice.js
@@ -40,7 +40,9 @@ export const huSlice = createSlice({
       // { id, key, value }
       const { id, key, value } = payload;
       const idx = state.initiatives.findIndex((i) => i.id === id);
-      if (idx !== -1) state.initiatives[idx][key] = value;
+      if (idx !== -1)
+        state.initiatives[idx][key] =
+          key === "sprintDays" ? Number(value) : value;
     },
     removeInitiativeById: (state, { payload }) => {
       // payload: id de la iniciativa


### PR DESCRIPTION
## Summary
- Respect completion date when computing effective today for finished tasks
- Allow setting business-day length per sprint and use it for burndown projections
- Apply a professional dark theme with hover highlights

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c48f0006508331b312bf363fffbfd1