### PR TITLE
feat: add responsive dashboard layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,49 +1,78 @@
 // src/App.jsx
-import React from "react";
-import { Outlet, Link } from "react-router-dom";
+import React, { useState } from "react";
+import { Outlet, Link, useLocation } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { logout } from "./store/authSlice";
 
 export default function App() {
   const dispatch = useDispatch();
   const isAuthenticated = useSelector((s) => s.auth.isAuthenticated);
+  const location = useLocation();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const handleLogout = () => dispatch(logout());
+  const toggleSidebar = () => setSidebarOpen((prev) => !prev);
 
   return (
-    <div className="d-flex flex-column min-vh-100">
-      {/* Navbar global */}
-      <nav className="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
+    <div>
+      {/* Top navbar */}
+      <nav className="navbar navbar-expand bg-white shadow-sm fixed-top">
         <div className="container-fluid">
-          <Link className="navbar-brand" to="/">HU Tracker</Link>
-          <div className="collapse navbar-collapse">
-            <ul className="navbar-nav ms-auto mb-2 mb-lg-0">
-              <li className="nav-item">
-                <Link className="nav-link" to="/">Historias</Link>
-              </li>
-              <li className="nav-item">
-                <Link className="nav-link" to="/initiatives">Iniciativas</Link>
-              </li>
-              {isAuthenticated ? (
-                <li className="nav-item">
-                  <button className="nav-link btn btn-link" onClick={handleLogout}>
-                    Logout
-                  </button>
-                </li>
-              ) : (
-                <li className="nav-item">
-                  <Link className="nav-link" to="/login">
-                    Login
-                  </Link>
-                </li>
-              )}
-            </ul>
+          {isAuthenticated && (
+            <button
+              className="btn btn-outline-primary d-md-none"
+              onClick={toggleSidebar}
+            >
+              ☰
+            </button>
+          )}
+          <Link className="navbar-brand ms-2" to="/">
+            HU Tracker
+          </Link>
+          <div className="ms-auto">
+            {isAuthenticated ? (
+              <button className="btn btn-outline-secondary" onClick={handleLogout}>
+                Logout
+              </button>
+            ) : (
+              <Link className="btn btn-primary" to="/login">
+                Login
+              </Link>
+            )}
           </div>
         </div>
       </nav>
 
-      {/* Aquí se renderizan las páginas */}
-      <main className="container py-4 flex-grow-1">
+      {/* Sidebar */}
+      {isAuthenticated && (
+        <aside className={`sidebar ${sidebarOpen ? "show" : ""}`}>
+          <ul className="nav flex-column px-3">
+            <li className="nav-item">
+              <Link
+                to="/"
+                className={`nav-link ${location.pathname === "/" ? "active" : ""}`}
+              >
+                Dashboard
+              </Link>
+            </li>
+            <li className="nav-item">
+              <Link
+                to="/initiatives"
+                className={`nav-link ${
+                  location.pathname.startsWith("/initiatives") ? "active" : ""
+                }`}
+              >
+                Iniciativas
+              </Link>
+            </li>
+          </ul>
+        </aside>
+      )}
+
+      {/* Main content */}
+      <main
+        className={`content-wrapper ${isAuthenticated ? "sidebar-active" : ""}`}
+      >
         <Outlet />
       </main>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,61 +1,96 @@
-/* Global theme for a modern management look */
+/* Global light theme for a clean dashboard look */
 body {
   font-family: "Inter", system-ui, -apple-system, sans-serif;
-  background-color: #121212;
-  color: #eaeaea;
+  background-color: #f5f5f9;
+  color: #495057;
 }
 
+/* Top navbar */
 .navbar {
-  border-bottom: 1px solid #2c2c2c;
+  border-bottom: 1px solid #e0e0e0;
+  z-index: 1030;
 }
 
+/* Sidebar layout */
+.sidebar {
+  width: 240px;
+  min-height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: #ffffff;
+  border-right: 1px solid #e0e0e0;
+  padding-top: 4.5rem;
+}
+
+.sidebar .nav-link {
+  color: #495057;
+  border-radius: 0.375rem;
+}
+
+.sidebar .nav-link.active,
+.sidebar .nav-link:hover {
+  background-color: #e7f1ff;
+  color: #0d6efd;
+}
+
+.content-wrapper {
+  padding: 5rem 1.5rem 1.5rem;
+  min-height: 100vh;
+  background-color: #f5f5f9;
+}
+
+.sidebar-active {
+  margin-left: 240px;
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    left: -240px;
+    transition: left 0.3s ease;
+  }
+  .sidebar.show {
+    left: 0;
+  }
+  .sidebar-active {
+    margin-left: 0;
+  }
+}
+
+/* Cards and tables */
 .card {
   border-radius: 0.5rem;
-  background-color: #1e1e1e;
-  border: 1px solid #2c2c2c;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-  transition: box-shadow 0.2s ease;
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
-.card:hover {
-  box-shadow: 0 4px 8px rgba(255, 255, 255, 0.1);
+.table thead th {
+  background-color: #f8f9fa;
 }
 
-table.table {
-  color: #eaeaea;
-}
-
-table.table thead th {
-  background-color: #2c2c2c;
-  color: #eaeaea;
-}
-
-table.table tbody tr:hover {
-  background-color: #333333;
-}
-
-/* Colores del SELECT por estado (evita duplicados visuales) */
+/* Status select colors */
 .status-select--todo {
-  background-color: #e9ecef;   /* gris claro */
+  background-color: #e9ecef;
   color: #212529;
 }
+
 .status-select--inprogress {
-  background-color: #ffe08a;   /* amarillo suave */
+  background-color: #ffe08a;
   color: #3a3a3a;
 }
+
 .status-select--done {
-  background-color: #198754;   /* verde bootstrap */
+  background-color: #198754;
   color: #ffffff;
 }
 
-/* Para que el texto no se “desaparezca” en algunos navegadores */
 .status-select--todo:focus,
 .status-select--inprogress:focus,
 .status-select--done:focus {
   color: inherit;
 }
 
-/* Opcional: quitar el “salto” visual del select en Safari/Edge */
 .status-select--todo,
 .status-select--inprogress,
 .status-select--done {

--- a/src/pages/HUTrackerPage.jsx
+++ b/src/pages/HUTrackerPage.jsx
@@ -168,7 +168,7 @@ export default function HUTrackerPage() {
   const onDeleteHU = (index) => dispatch(removeHU(index));
 
   return (
-    <div className="container py-4">
+    <div className="container-fluid py-4">
       <div className="d-flex align-items-center justify-content-between mb-3">
         <h2 className="m-0">
           📊 Historias de Usuario —{" "}

--- a/src/pages/InitiativeDetailPage.jsx
+++ b/src/pages/InitiativeDetailPage.jsx
@@ -9,11 +9,12 @@ export default function InitiativeDetailPage() {
   if (!initiative) return <p>Iniciativa no encontrada</p>;
 
   return (
-    <div>
+    <div className="container-fluid">
       <h2 className="mb-4">📊 {initiative.name}</h2>
       <div className="card shadow-sm">
         <div className="card-body">
-          <table className="table table-striped align-middle">
+          <div className="table-responsive">
+            <table className="table table-striped align-middle">
             <thead>
               <tr>
                 <th>Title</th>
@@ -39,6 +40,7 @@ export default function InitiativeDetailPage() {
               ))}
             </tbody>
           </table>
+          </div>
           <Link to="/initiatives-overview" className="btn btn-secondary mt-3">
             Volver
           </Link>

--- a/src/pages/InitiativesOverviewPage.jsx
+++ b/src/pages/InitiativesOverviewPage.jsx
@@ -119,7 +119,7 @@ export default function InitiativesOverviewPage() {
   };
 
   return (
-    <div>
+    <div className="container-fluid">
       <h2 className="mb-4">📈 Resumen por Iniciativa</h2>
 
       {/* Formulario para nueva iniciativa */}

--- a/src/pages/InitiativesSummaryPage.jsx
+++ b/src/pages/InitiativesSummaryPage.jsx
@@ -27,7 +27,7 @@ export default function InitiativesSummaryPage() {
   }, [items]);
 
   return (
-    <div className="container py-4">
+    <div className="container-fluid py-4">
       <div className="d-flex align-items-center justify-content-between mb-3">
         <h2 className="m-0">📈 Resumen por Iniciativa</h2>
         <nav>


### PR DESCRIPTION
## Summary
- add responsive dashboard layout with fixed navbar and collapsible sidebar
- switch to light theme and improve table/card styling
- ensure main pages use fluid containers and responsive tables

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4a46833408331869de4401eb942c3