### PR TITLE
Streamline navigation and improve HU table visuals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,16 +52,6 @@ export default function App() {
                 to="/"
                 className={`nav-link ${location.pathname === "/" ? "active" : ""}`}
               >
-                Dashboard
-              </Link>
-            </li>
-            <li className="nav-item">
-              <Link
-                to="/initiatives"
-                className={`nav-link ${
-                  location.pathname.startsWith("/initiatives") ? "active" : ""
-                }`}
-              >
                 Iniciativas
               </Link>
             </li>

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -18,7 +18,6 @@ const router = createBrowserRouter([
         element: <ProtectedRoute />,
         children: [
           { index: true, element: <InitiativesOverviewPage /> },
-          { path: "initiatives", element: <InitiativesOverviewPage /> },
           { path: "initiatives/:id", element: <HUTrackerPage /> },
         ],
       },

--- a/src/components/HUTable.jsx
+++ b/src/components/HUTable.jsx
@@ -19,7 +19,7 @@ export default function HUTable({
   };
 
   return (
-    <div className="card shadow-sm">
+    <div className="card shadow-sm hu-table-card">
       <div className="card-body">
         {/* Header con título y filtro sprint */}
         <div className="d-flex justify-content-between align-items-center mb-3">

--- a/src/index.css
+++ b/src/index.css
@@ -96,3 +96,13 @@ body {
 .status-select--done {
   background-image: none;
 }
+
+/* HU table styling */
+.hu-table-card {
+  border-color: #cfe2ff;
+}
+
+.hu-table-card .table thead th {
+  background-color: #e7f1ff;
+  color: #0d6efd;
+}

--- a/src/pages/HUTrackerPage.jsx
+++ b/src/pages/HUTrackerPage.jsx
@@ -175,7 +175,7 @@ export default function HUTrackerPage() {
           <span className="text-primary">{selectedInitiative || "…"}</span>
         </h2>
         <nav>
-          <Link to="/initiatives" className="btn btn-outline-secondary">
+          <Link to="/" className="btn btn-outline-secondary">
             Volver a Iniciativas
           </Link>
         </nav>


### PR DESCRIPTION
## Summary
- Remove duplicate sidebar entry and rename dashboard link to Iniciativas
- Drop unused initiatives route and update HU tracker back link
- Refresh HU table card colors to match app palette

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4a833161083318442d55bcd544bef