### PR TITLE
Add sprint-based projections and date validations

### DIFF
--- a/src/components/HUForm.jsx
+++ b/src/components/HUForm.jsx
@@ -1,7 +1,14 @@
 import React from "react";
 import StatusSelect from "./StatusSelect";
 
-export default function HUForm({ newHU, setNewHU, handleAddHU }) {
+export default function HUForm({
+  newHU,
+  setNewHU,
+  handleAddHU,
+  minStart,
+  maxEnd,
+  sprintLimit,
+}) {
   return (
     <div className="card shadow-sm mb-4">
       <div className="card-body">
@@ -48,7 +55,9 @@ export default function HUForm({ newHU, setNewHU, handleAddHU }) {
           <div className="col-md-6">
             <label className="form-label">Sprint</label>
             <input
-              type="text"
+              type="number"
+              min={1}
+              max={sprintLimit || undefined}
               className="form-control"
               value={newHU["Sprint"]}
               onChange={(e) =>
@@ -61,6 +70,8 @@ export default function HUForm({ newHU, setNewHU, handleAddHU }) {
             <input
               type="date"
               className="form-control"
+              min={minStart}
+              max={maxEnd || undefined}
               value={newHU["Start Date"]}
               onChange={(e) =>
                 setNewHU({ ...newHU, "Start Date": e.target.value })
@@ -72,6 +83,8 @@ export default function HUForm({ newHU, setNewHU, handleAddHU }) {
             <input
               type="date"
               className="form-control"
+              min={newHU["Start Date"] || minStart}
+              max={maxEnd || undefined}
               value={newHU["Due Date"]}
               onChange={(e) =>
                 setNewHU({ ...newHU, "Due Date": e.target.value })

--- a/src/components/HUTable.jsx
+++ b/src/components/HUTable.jsx
@@ -9,6 +9,9 @@ export default function HUTable({
   availableSprints,
   selectedSprint,
   setSelectedSprint,
+  startLimit,
+  endLimit,
+  sprintLimit,
 }) {
   const getDeviation = (dueDate, completed, original) => {
     if (!dueDate) return "-";
@@ -141,7 +144,9 @@ export default function HUTable({
                     </td>
                     <td>
                       <input
-                        type="text"
+                        type="number"
+                        min={1}
+                        max={sprintLimit || undefined}
                         className="form-control form-control-sm"
                         value={row.Sprint || ""}
                         onChange={(e) =>
@@ -153,6 +158,8 @@ export default function HUTable({
                       <input
                         type="date"
                         className="form-control form-control-sm"
+                        min={startLimit}
+                        max={endLimit || undefined}
                         value={row["Start Date"] || ""}
                         onChange={(e) =>
                           handleEdit(idx, "Start Date", e.target.value)
@@ -163,6 +170,8 @@ export default function HUTable({
                       <input
                         type="date"
                         className="form-control form-control-sm"
+                        min={row["Start Date"] || startLimit}
+                        max={endLimit || undefined}
                         value={row["Due Date"] || ""}
                         onChange={(e) =>
                           handleEdit(idx, "Due Date", e.target.value)


### PR DESCRIPTION
## Summary
- Show sprint numbers from initiative stories in HU tracker
- Enforce sprint and date ranges when creating or editing user stories
- Calculate initiative sprint schedules with projected completion dates

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c4c85ed35c83319deefaebe8321fa8