### PR TITLE
feat: modernize initiative table styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -106,3 +106,77 @@ body {
   background-color: #e7f1ff;
   color: #0d6efd;
 }
+
+/* Modern table styling */
+.table-modern {
+  border: 1px solid #dee2e6;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.table-modern thead th {
+  background-color: #f9fafb;
+  font-weight: 600;
+}
+
+.table-modern tbody tr:nth-child(odd) {
+  background-color: #fcfcfd;
+}
+
+.table-modern tbody tr:hover {
+  background-color: #f1f5f9;
+}
+
+/* Status badges */
+.badge-status-delay {
+  background-color: #ff6b6b;
+  color: #fff;
+}
+
+.badge-status-ontime {
+  background-color: #51cf66;
+  color: #fff;
+}
+
+/* Metric badges */
+.badge-hours {
+  background-color: #0d6efd;
+  color: #fff;
+}
+
+/* Progress bars */
+.progress {
+  height: 0.75rem;
+  background-color: #e9ecef;
+}
+
+.progress-bar.completed {
+  background-color: #198754;
+}
+
+.progress-bar.debt {
+  background-color: #dc3545;
+}
+
+/* Action buttons */
+.btn-view {
+  background-color: #0d6efd;
+  color: #fff;
+}
+
+.btn-delete {
+  color: #dc3545;
+  border: 1px solid #dc3545;
+  background-color: transparent;
+}
+
+.btn-delete:hover {
+  background-color: #dc3545;
+  color: #fff;
+}
+
+@media (max-width: 576px) {
+  .table-responsive .table {
+    font-size: 0.875rem;
+  }
+}

--- a/src/pages/InitiativesOverviewPage.jsx
+++ b/src/pages/InitiativesOverviewPage.jsx
@@ -294,8 +294,8 @@ export default function InitiativesOverviewPage() {
     </div>
 
     <div className="table-responsive">
-      <table className="table table-hover align-middle">
-        <thead className="table-light">
+      <table className="table table-hover align-middle table-modern">
+        <thead>
           <tr>
             <th>Initiative</th>
             <th>Start Date</th>
@@ -356,25 +356,27 @@ export default function InitiativesOverviewPage() {
                 </td>
                 <td>{row.totalHU}</td>
                 <td>{row.original}</td>
-                <td>{row.completed}</td>
+                <td>
+                  <span className="badge badge-hours">{row.completed}</span>
+                </td>
                 <td>{row.remaining}</td>
                 <td>{row.projectedDelay}</td>
                 <td>
                   {row.hasDelay ? (
-                    <span className="badge bg-danger">Con retrasos</span>
+                    <span className="badge badge-status-delay">Con retrasos</span>
                   ) : (
-                    <span className="badge bg-success">En tiempo</span>
+                    <span className="badge badge-status-ontime">En tiempo</span>
                   )}
                 </td>
                 <td className="d-flex gap-2">
                   <Link
                     to={`/initiatives/${row.id}`}
-                    className="btn btn-sm btn-outline-primary"
+                    className="btn btn-sm btn-view"
                   >
                     Ver HU
                   </Link>
                   <button
-                    className="btn btn-sm btn-danger"
+                    className="btn btn-sm btn-delete"
                     onClick={() => handleDeleteById(row.id)}
                   >
                     🗑
@@ -389,7 +391,7 @@ export default function InitiativesOverviewPage() {
                       % por sprint
                     </div>
                     <div className="table-responsive">
-                      <table className="table table-sm mb-0">
+                      <table className="table table-sm mb-0 table-modern">
                         <thead>
                           <tr>
                             <th>#</th>
@@ -411,10 +413,36 @@ export default function InitiativesOverviewPage() {
                               <td>{s.end}</td>
                               <td>{s.projectedEnd}</td>
                               <td>{s.expectedHours}</td>
-                              <td>{s.completedHours}</td>
+                              <td>
+                                <span className="badge badge-hours">{s.completedHours}</span>
+                              </td>
                               <td>{s.debtHours}</td>
-                              <td>{s.completedPercent}%</td>
-                              <td>{s.debtPercent}%</td>
+                              <td>
+                                <div className="d-flex align-items-center gap-2">
+                                  <div className="progress flex-grow-1">
+                                    <div
+                                      className="progress-bar completed"
+                                      style={{ width: `${s.completedPercent}%` }}
+                                    ></div>
+                                  </div>
+                                  <span className="small fw-semibold">
+                                    {s.completedPercent}%
+                                  </span>
+                                </div>
+                              </td>
+                              <td>
+                                <div className="d-flex align-items-center gap-2">
+                                  <div className="progress flex-grow-1">
+                                    <div
+                                      className="progress-bar debt"
+                                      style={{ width: `${s.debtPercent}%` }}
+                                    ></div>
+                                  </div>
+                                  <span className="small fw-semibold">
+                                    {s.debtPercent}%
+                                  </span>
+                                </div>
+                              </td>
                             </tr>
                           ))}
                         </tbody>


### PR DESCRIPTION
## Summary
- enhance initiative overview tables with modern styling and progress bars
- add status and metric badges with distinct colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c78f476bbc833196eada89e70b1ad8