### PR TITLE
feat: add light theme and pagination

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,9 +14,9 @@ export default function App() {
   const toggleSidebar = () => setSidebarOpen((prev) => !prev);
 
   return (
-    <div className="bg-dark text-light min-vh-100">
+    <div className="bg-light text-dark min-vh-100">
       {/* Top navbar */}
-      <nav className="navbar navbar-dark bg-dark shadow fixed-top">
+      <nav className="navbar navbar-light bg-white border-bottom shadow fixed-top">
         <div className="container-fluid">
           {isAuthenticated && (
             <button
@@ -49,12 +49,12 @@ export default function App() {
       {/* Sidebar */}
       {isAuthenticated && (
         <aside
-          className={`sidebar ${sidebarOpen ? "" : "d-none"} d-md-block bg-dark`}
+          className={`sidebar ${sidebarOpen ? "" : "d-none"} d-md-block bg-white`}
         >
           <nav className="nav flex-column">
             <Link
               to="/"
-              className={`nav-link text-light ${
+              className={`nav-link text-dark ${
                 location.pathname === "/" ? "active" : ""
               }`}
               onClick={() => setSidebarOpen(false)}

--- a/src/components/BurndownChart.jsx
+++ b/src/components/BurndownChart.jsx
@@ -38,8 +38,8 @@ export default function BurndownChart({ burndownData, initiative }) {
 
   if (data.length === 0) return null;
 
-  return (
-    <div className="card bg-dark text-light mt-4">
+    return (
+      <div className="card bg-white text-dark mt-4">
       <div className="card-body">
         <h5 className="card-title mb-4">
           Avance por HU — {initiative || "General"}

--- a/src/components/HUForm.jsx
+++ b/src/components/HUForm.jsx
@@ -9,8 +9,8 @@ export default function HUForm({
   maxEnd,
   sprintLimit,
 }) {
-  return (
-    <div className="card bg-dark text-light mb-4">
+    return (
+      <div className="card bg-white text-dark mb-4">
       <div className="card-body">
         <h5 className="card-title mb-4">Agregar Historia de Usuario</h5>
         <div className="row g-3">

--- a/src/components/HUTable.jsx
+++ b/src/components/HUTable.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import StatusSelect from "./StatusSelect";
 import { calculateElapsedAndDelay } from "../utils/timeCalculations";
 
@@ -12,18 +12,26 @@ export default function HUTable({
   startLimit,
   endLimit,
   sprintLimit,
-}) {
-  const getDeviation = (dueDate, completed, original) => {
-    if (!dueDate) return "-";
-    const today = new Date();
-    const due = new Date(dueDate);
-    if (completed >= original) return "Cumplida";
-    return today >= due ? "Retrasada" : "Adelantada";
-  };
+  }) {
+    const getDeviation = (dueDate, completed, original) => {
+      if (!dueDate) return "-";
+      const today = new Date();
+      const due = new Date(dueDate);
+      if (completed >= original) return "Cumplida";
+      return today >= due ? "Retrasada" : "Adelantada";
+    };
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 10;
+    useEffect(() => {
+      setCurrentPage(1);
+    }, [data]);
+    const totalPages = Math.ceil(data.length / itemsPerPage);
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const paginated = data.slice(startIndex, startIndex + itemsPerPage);
 
-  return (
-    <div className="card bg-dark text-light">
-      <div className="card-body">
+    return (
+      <div className="card bg-white text-dark">
+        <div className="card-body">
         <div className="d-flex justify-content-between align-items-center mb-3">
           <h5 className="card-title m-0">Listado de Historias de Usuario</h5>
           {availableSprints?.length > 1 && (
@@ -45,7 +53,7 @@ export default function HUTable({
         </div>
 
         <div className="table-responsive">
-          <table className="table table-dark table-striped table-sm align-middle">
+          <table className="table table-striped table-sm align-middle">
             <thead>
               <tr>
                 <th style={{ minWidth: "200px" }}>Title</th>
@@ -65,145 +73,185 @@ export default function HUTable({
                 <th>Acción</th>
               </tr>
             </thead>
-            <tbody>
-              {data.map((row, idx) => {
-                const effectiveToday =
-                  row.State === "Done" &&
-                  Number(row["Completed Work"]) >= Number(row["Original Estimate"])
-                    ? new Date(
-                        row["Completion Date"] ||
-                          row["Due Date"] ||
-                          row["Start Date"]
-                      )
-                    : new Date();
-                const { elapsedDays, delayHours, delayDays } =
-                  calculateElapsedAndDelay(
-                    new Date(row["Start Date"]),
-                    new Date(row["Completion Date"] || row["Due Date"]),
-                    effectiveToday,
-                    Number(row["Original Estimate"]) || 0,
-                    Number(row["Completed Work"]) || 0
-                  );
+              <tbody>
+                {paginated.map((row, idx) => {
+                  const effectiveToday =
+                    row.State === "Done" &&
+                    Number(row["Completed Work"]) >= Number(row["Original Estimate"])
+                      ? new Date(
+                          row["Completion Date"] ||
+                            row["Due Date"] ||
+                            row["Start Date"]
+                        )
+                      : new Date();
+                  const { elapsedDays, delayHours, delayDays } =
+                    calculateElapsedAndDelay(
+                      new Date(row["Start Date"]),
+                      new Date(row["Completion Date"] || row["Due Date"]),
+                      effectiveToday,
+                      Number(row["Original Estimate"]) || 0,
+                      Number(row["Completed Work"]) || 0
+                    );
 
-                return (
-                  <tr
-                    key={idx}
-                    className={`${delayHours > 0 ? "table-danger" : ""} ${
-                      row.isAdditional ? "table-warning" : ""
-                    }`}
-                  >
-                    <td>
-                      <input
-                        type="text"
-                        className="form-control form-control-sm"
-                        value={row.Title || ""}
-                        onChange={(e) => handleEdit(idx, "Title", e.target.value)}
-                      />
-                    </td>
-                    <td>
-                      <StatusSelect
-                        value={row.State}
-                        onChange={(e) => handleEdit(idx, "State", e.target.value)}
-                      />
-                    </td>
-                    <td>
-                      <input
-                        type="text"
-                        className="form-control form-control-sm"
-                        value={row["Assigned To"] || ""}
-                        onChange={(e) =>
-                          handleEdit(idx, "Assigned To", e.target.value)
-                        }
-                      />
-                    </td>
-                    <td>
-                      <input
-                        type="number"
-                        className="form-control form-control-sm"
-                        value={row["Original Estimate"] || ""}
-                        onChange={(e) =>
-                          handleEdit(idx, "Original Estimate", e.target.value)
-                        }
-                      />
-                    </td>
-                    <td>{row["Remaining Work"]}</td>
-                    <td>
-                      <input
-                        type="number"
-                        className="form-control form-control-sm"
-                        value={row["Completed Work"] || 0}
-                        onChange={(e) =>
-                          handleEdit(idx, "Completed Work", e.target.value)
-                        }
-                      />
-                    </td>
-                    <td>
-                      <input
-                        type="number"
-                        min={1}
-                        max={sprintLimit || undefined}
-                        className="form-control form-control-sm"
-                        value={row.Sprint || ""}
-                        onChange={(e) => handleEdit(idx, "Sprint", e.target.value)}
-                      />
-                    </td>
-                    <td>
-                      <input
-                        type="date"
-                        className="form-control form-control-sm"
-                        min={startLimit}
-                        max={endLimit || undefined}
-                        value={row["Start Date"] || ""}
-                        onChange={(e) => handleEdit(idx, "Start Date", e.target.value)}
-                      />
-                    </td>
-                    <td>
-                      <input
-                        type="date"
-                        className="form-control form-control-sm"
-                        min={row["Start Date"] || startLimit}
-                        value={row["Due Date"] || ""}
-                        onChange={(e) => handleEdit(idx, "Due Date", e.target.value)}
-                      />
-                    </td>
-                    <td>{elapsedDays}</td>
-                    <td>{delayHours}</td>
-                    <td>{delayDays}</td>
-                    <td>
-                      <span
-                        className={
-                          getDeviation(
+                  const actualIndex = startIndex + idx;
+                  return (
+                    <tr
+                      key={actualIndex}
+                      className={`${delayHours > 0 ? "table-danger" : ""} ${
+                        row.isAdditional ? "table-warning" : ""
+                      }`}
+                    >
+                      <td>
+                        <input
+                          type="text"
+                          className="form-control form-control-sm"
+                          value={row.Title || ""}
+                          onChange={(e) => handleEdit(actualIndex, "Title", e.target.value)}
+                        />
+                      </td>
+                      <td>
+                        <StatusSelect
+                          value={row.State}
+                          onChange={(e) => handleEdit(actualIndex, "State", e.target.value)}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="text"
+                          className="form-control form-control-sm"
+                          value={row["Assigned To"] || ""}
+                          onChange={(e) =>
+                            handleEdit(actualIndex, "Assigned To", e.target.value)
+                          }
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="number"
+                          className="form-control form-control-sm"
+                          value={row["Original Estimate"] || ""}
+                          onChange={(e) =>
+                            handleEdit(actualIndex, "Original Estimate", e.target.value)
+                          }
+                        />
+                      </td>
+                      <td>{row["Remaining Work"]}</td>
+                      <td>
+                        <input
+                          type="number"
+                          className="form-control form-control-sm"
+                          value={row["Completed Work"] || 0}
+                          onChange={(e) =>
+                            handleEdit(actualIndex, "Completed Work", e.target.value)
+                          }
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="number"
+                          min={1}
+                          max={sprintLimit || undefined}
+                          className="form-control form-control-sm"
+                          value={row.Sprint || ""}
+                          onChange={(e) => handleEdit(actualIndex, "Sprint", e.target.value)}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="date"
+                          className="form-control form-control-sm"
+                          min={startLimit}
+                          max={endLimit || undefined}
+                          value={row["Start Date"] || ""}
+                          onChange={(e) => handleEdit(actualIndex, "Start Date", e.target.value)}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="date"
+                          className="form-control form-control-sm"
+                          min={row["Start Date"] || startLimit}
+                          value={row["Due Date"] || ""}
+                          onChange={(e) => handleEdit(actualIndex, "Due Date", e.target.value)}
+                        />
+                      </td>
+                      <td>{elapsedDays}</td>
+                      <td>{delayHours}</td>
+                      <td>{delayDays}</td>
+                      <td>
+                        <span
+                          className={
+                            getDeviation(
+                              row["Due Date"],
+                              row["Completed Work"],
+                              row["Original Estimate"]
+                            ) === "Retrasada"
+                              ? "text-danger fw-bold"
+                              : "text-success fw-bold"
+                          }
+                        >
+                          {getDeviation(
                             row["Due Date"],
                             row["Completed Work"],
                             row["Original Estimate"]
-                          ) === "Retrasada"
-                            ? "text-danger fw-bold"
-                            : "text-success fw-bold"
-                        }
-                      >
-                        {getDeviation(
-                          row["Due Date"],
-                          row["Completed Work"],
-                          row["Original Estimate"]
-                        )}
-                      </span>
-                    </td>
-                    <td>{row.isAdditional ? "⚠️" : ""}</td>
-                    <td>
+                          )}
+                        </span>
+                      </td>
+                      <td>{row.isAdditional ? "⚠️" : ""}</td>
+                      <td>
+                        <button
+                          className="btn btn-danger btn-sm"
+                          onClick={() => onDelete(actualIndex)}
+                        >
+                          🗑
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {totalPages > 1 && (
+              <nav className="mt-3">
+                <ul className="pagination pagination-sm mb-0">
+                  <li className={`page-item ${currentPage === 1 ? "disabled" : ""}`}>
+                    <button
+                      className="page-link"
+                      onClick={() => setCurrentPage((p) => p - 1)}
+                    >
+                      Anterior
+                    </button>
+                  </li>
+                  {Array.from({ length: totalPages }, (_, i) => (
+                    <li
+                      key={i}
+                      className={`page-item ${currentPage === i + 1 ? "active" : ""}`}
+                    >
                       <button
-                        className="btn btn-danger btn-sm"
-                        onClick={() => onDelete(idx)}
+                        className="page-link"
+                        onClick={() => setCurrentPage(i + 1)}
                       >
-                        🗑
+                        {i + 1}
                       </button>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                    </li>
+                  ))}
+                  <li
+                    className={`page-item ${
+                      currentPage === totalPages ? "disabled" : ""
+                    }`}
+                  >
+                    <button
+                      className="page-link"
+                      onClick={() => setCurrentPage((p) => p + 1)}
+                    >
+                      Siguiente
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            )}
+          </div>
         </div>
       </div>
-    </div>
-  );
-}
+    );
+  }

--- a/src/components/SprintBurndownChart.jsx
+++ b/src/components/SprintBurndownChart.jsx
@@ -79,8 +79,8 @@ export default function SprintBurndownChart({ tasks, sprintDays }) {
 
   if (!points.length) return null;
 
-  return (
-    <div className="card bg-dark text-light mt-4">
+    return (
+      <div className="card bg-white text-dark mt-4">
       <div className="card-body">
         <h5 className="card-title mb-4">Burndown Chart</h5>
         <ResponsiveContainer width="100%" height={300}>

--- a/src/index.css
+++ b/src/index.css
@@ -8,8 +8,8 @@ body {
   bottom: 0;
   left: 0;
   width: 14rem;
-  background-color: #212529;
-  color: #f8f9fa;
+  background-color: #fff;
+  color: #212529;
   padding: 1rem;
   overflow-y: auto;
 }

--- a/src/pages/InitiativeDetailPage.jsx
+++ b/src/pages/InitiativeDetailPage.jsx
@@ -1,20 +1,26 @@
-import React from "react";
+import React, { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { initiativesMock } from "../mocks/initiativesMock";
 
 export default function InitiativeDetailPage() {
   const { id } = useParams();
   const initiative = initiativesMock.find((ini) => ini.id === id);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
+  const stories = initiative?.stories || [];
+  const totalPages = Math.ceil(stories.length / itemsPerPage);
+  const start = (currentPage - 1) * itemsPerPage;
+  const paginated = stories.slice(start, start + itemsPerPage);
 
   if (!initiative) return <p>Iniciativa no encontrada</p>;
 
   return (
     <div className="container-fluid py-4">
       <h2 className="mb-4">📊 {initiative.name}</h2>
-      <div className="card bg-dark text-light">
+      <div className="card bg-white text-dark">
         <div className="card-body">
           <div className="table-responsive">
-            <table className="table table-dark table-striped table-sm align-middle">
+            <table className="table table-striped table-sm align-middle">
               <thead>
                 <tr>
                   <th>Title</th>
@@ -27,7 +33,7 @@ export default function InitiativeDetailPage() {
                 </tr>
               </thead>
               <tbody>
-                {initiative.stories.map((hu) => (
+                {paginated.map((hu) => (
                   <tr key={hu.id}>
                     <td>{hu.Title}</td>
                     <td>{hu.State}</td>
@@ -40,6 +46,43 @@ export default function InitiativeDetailPage() {
                 ))}
               </tbody>
             </table>
+            {totalPages > 1 && (
+              <nav className="mt-3">
+                <ul className="pagination pagination-sm mb-0">
+                  <li className={`page-item ${currentPage === 1 ? "disabled" : ""}`}>
+                    <button
+                      className="page-link"
+                      onClick={() => setCurrentPage((p) => p - 1)}
+                    >
+                      Anterior
+                    </button>
+                  </li>
+                  {Array.from({ length: totalPages }, (_, i) => (
+                    <li
+                      key={i}
+                      className={`page-item ${currentPage === i + 1 ? "active" : ""}`}
+                    >
+                      <button
+                        className="page-link"
+                        onClick={() => setCurrentPage(i + 1)}
+                      >
+                        {i + 1}
+                      </button>
+                    </li>
+                  ))}
+                  <li
+                    className={`page-item ${currentPage === totalPages ? "disabled" : ""}`}
+                  >
+                    <button
+                      className="page-link"
+                      onClick={() => setCurrentPage((p) => p + 1)}
+                    >
+                      Siguiente
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            )}
           </div>
           <Link to="/initiatives-overview" className="btn btn-outline-secondary mt-4">
             Volver

--- a/src/pages/InitiativesOverviewPage.jsx
+++ b/src/pages/InitiativesOverviewPage.jsx
@@ -178,6 +178,17 @@ export default function InitiativesOverviewPage() {
     });
   }, [initiatives]);
 
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 5;
+  const totalPages = Math.ceil(summary.length / itemsPerPage);
+  const paginatedSummary = useMemo(() => {
+    const start = (currentPage - 1) * itemsPerPage;
+    return summary.slice(start, start + itemsPerPage);
+  }, [summary, currentPage]);
+  useEffect(() => {
+    if (currentPage > totalPages) setCurrentPage(totalPages || 1);
+  }, [totalPages, currentPage]);
+
   const handleAddInitiative = () => {
     if (!newIni.name) return;
     const todayStr = new Date().toISOString().slice(0, 10);
@@ -220,7 +231,7 @@ export default function InitiativesOverviewPage() {
       <h2 className="mb-4">📈 Resumen por Iniciativa</h2>
 
       {/* Formulario para nueva iniciativa */}
-      <div className="card bg-dark text-light mb-4">
+      <div className="card bg-white text-dark mb-4">
         <div className="card-body">
           <h5 className="card-title mb-4">Agregar Nueva Iniciativa</h5>
           <div className="row g-3">
@@ -285,11 +296,11 @@ export default function InitiativesOverviewPage() {
 
       {/* Listado de iniciativas */}
       <div className="d-flex flex-column gap-4">
-        {summary.map((row) => (
-          <div key={row.id} className="card bg-dark text-light">
+        {paginatedSummary.map((row) => (
+          <div key={row.id} className="card bg-white text-dark">
             <div className="card-body">
               <div className="table-responsive">
-                <table className="table table-dark table-striped table-sm align-middle">
+                <table className="table table-striped table-sm align-middle">
                   <thead>
                     <tr>
                       <th className="text-start">Initiative</th>
@@ -384,7 +395,7 @@ export default function InitiativesOverviewPage() {
                     Estimado teórico: {row.totalSprints} sprints, {row.expectedPercentPerSprint}% por sprint
                   </div>
                   <div className="table-responsive">
-                    <table className="table table-dark table-striped table-sm align-middle">
+                      <table className="table table-striped table-sm align-middle">
                       <thead>
                         <tr>
                           <th>#</th>
@@ -451,6 +462,45 @@ export default function InitiativesOverviewPage() {
           <div className="text-center text-muted">
             No hay iniciativas, agrega una arriba.
           </div>
+        )}
+        {totalPages > 1 && summary.length > 0 && (
+          <nav className="mt-3">
+            <ul className="pagination pagination-sm mb-0">
+              <li className={`page-item ${currentPage === 1 ? "disabled" : ""}`}>
+                <button
+                  className="page-link"
+                  onClick={() => setCurrentPage((p) => p - 1)}
+                >
+                  Anterior
+                </button>
+              </li>
+              {Array.from({ length: totalPages }, (_, i) => (
+                <li
+                  key={i}
+                  className={`page-item ${currentPage === i + 1 ? "active" : ""}`}
+                >
+                  <button
+                    className="page-link"
+                    onClick={() => setCurrentPage(i + 1)}
+                  >
+                    {i + 1}
+                  </button>
+                </li>
+              ))}
+              <li
+                className={`page-item ${
+                  currentPage === totalPages ? "disabled" : ""
+                }`}
+              >
+                <button
+                  className="page-link"
+                  onClick={() => setCurrentPage((p) => p + 1)}
+                >
+                  Siguiente
+                </button>
+              </li>
+            </ul>
+          </nav>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- switch to a light Bootstrap theme for layout and components
- paginate initiative lists (5 per page) and task tables (10 per page)

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c798db47088331aa6179203eb5f973