### PR TITLE
feat: enhance sprint burndown chart with baseline and tooltip details

### DIFF
--- a/src/pages/HUTrackerPage.jsx
+++ b/src/pages/HUTrackerPage.jsx
@@ -300,6 +300,7 @@ export default function HUTrackerPage() {
       <SprintBurndownChart
         tasks={sprintFiltered}
         sprintDays={currentInitiative?.sprintDays}
+        sprintName={selectedSprint}
       />
 
       {/* Detalle por HU */}


### PR DESCRIPTION
## Summary
- add baseline line and deviation markers to sprint burndown
- provide custom tooltip with sprint name, remaining work and delay/ahead messages
- wire sprint filter to chart and keep projection using actual velocity with linear regression fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c828a4dd5083319371c8c3942de707