### PR TITLE
Refine contacts page styling

### DIFF
--- a/src/pages/ContactsPage.css
+++ b/src/pages/ContactsPage.css
@@ -1,0 +1,277 @@
+.contacts-page {
+  background: linear-gradient(180deg, #f5f7fb 0%, #edf1f7 100%);
+  min-height: calc(100vh - 56px);
+  padding: 3rem 0 4rem;
+}
+
+.contacts-container {
+  max-width: 1100px;
+}
+
+.contacts-header {
+  text-align: center;
+  margin-bottom: 2.75rem;
+}
+
+.contacts-title {
+  font-size: clamp(2rem, 2vw + 1.4rem, 2.6rem);
+  color: #1f2937;
+  margin-bottom: 0.75rem;
+}
+
+.contacts-subtitle {
+  color: #6b7280;
+  font-size: 1.05rem;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.contacts-content-row {
+  align-items: stretch;
+}
+
+.contacts-column {
+  display: flex;
+}
+
+.contacts-column .card {
+  width: 100%;
+}
+
+.contacts-page .card {
+  border: none;
+  border-radius: 20px;
+  box-shadow: 0 28px 45px -25px rgba(15, 23, 42, 0.35);
+  background-color: #ffffff;
+  height: 100%;
+}
+
+.contacts-page .card-body {
+  padding: 2.25rem 2.5rem;
+}
+
+.contacts-section-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.contacts-form .form-label {
+  font-weight: 600;
+  color: #4b5563;
+}
+
+.contacts-page .form-control {
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  padding: 0.65rem 0.85rem;
+  background-color: #f9fafb;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.contacts-page .form-control:focus {
+  background-color: #ffffff;
+  border-color: #22c55e;
+  box-shadow: 0 0 0 0.25rem rgba(34, 197, 94, 0.18);
+}
+
+.contacts-page .form-control::placeholder {
+  color: #9ca3af;
+}
+
+.contacts-cancel {
+  border-radius: 999px;
+  font-weight: 600;
+  color: #6b7280;
+  border-color: #d1d5db;
+  padding: 0.5rem 1.4rem;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.contacts-cancel:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+  border-color: #cbd5e1;
+}
+
+.btn-save {
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #34d399, #16a34a);
+  color: #ffffff;
+  font-weight: 600;
+  padding: 0.5rem 1.6rem;
+  box-shadow: 0 18px 35px -22px rgba(16, 185, 129, 0.9);
+  transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.btn-save:hover,
+.btn-save:focus {
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 22px 38px -22px rgba(16, 185, 129, 0.95);
+  filter: brightness(1.03);
+}
+
+.btn-save:active {
+  transform: translateY(0);
+}
+
+.contacts-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.contacts-actions .btn {
+  border-radius: 999px;
+  padding: 0.45rem 1.4rem;
+  font-weight: 600;
+  border: none;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.btn-edit {
+  background: linear-gradient(135deg, #34d399, #16a34a);
+  color: #ffffff;
+  box-shadow: 0 18px 35px -22px rgba(16, 185, 129, 0.9);
+}
+
+.btn-edit:hover,
+.btn-edit:focus {
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 22px 38px -22px rgba(16, 185, 129, 0.95);
+  filter: brightness(1.03);
+}
+
+.btn-delete {
+  background: linear-gradient(135deg, #f87171, #ef4444);
+  color: #ffffff;
+  box-shadow: 0 18px 35px -22px rgba(239, 68, 68, 0.85);
+}
+
+.btn-delete:hover,
+.btn-delete:focus {
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 22px 38px -22px rgba(239, 68, 68, 0.9);
+  filter: brightness(1.03);
+}
+
+.contacts-actions .btn:active {
+  transform: translateY(0);
+}
+
+.contacts-team-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background-color: rgba(37, 99, 235, 0.1);
+  color: #2563eb;
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.contact-email {
+  color: #2563eb;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.contact-email:hover {
+  color: #1d4ed8;
+  text-decoration: underline;
+}
+
+.contact-whatsapp {
+  color: #16a34a;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.contact-whatsapp:hover {
+  color: #15803d;
+  text-decoration: underline;
+}
+
+.contacts-table {
+  width: 100%;
+  margin-bottom: 0;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.contacts-table thead th {
+  background-color: #f4f6fb;
+  color: #1f2937;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.75rem 1.25rem;
+  border-bottom: none;
+}
+
+.contacts-table thead th:first-child {
+  border-top-left-radius: 14px;
+}
+
+.contacts-table thead th:last-child {
+  border-top-right-radius: 14px;
+}
+
+.contacts-table tbody td {
+  padding: 1rem 1.25rem;
+  color: #374151;
+  border-top: 1px solid #e5e9f2;
+}
+
+.contacts-table tbody tr:first-child td {
+  border-top: none;
+}
+
+.contacts-table tbody tr {
+  transition: background-color 0.2s ease;
+}
+
+.contacts-table tbody tr:hover td {
+  background-color: #f5f7fb;
+}
+
+@media (max-width: 1199.98px) {
+  .contacts-page {
+    padding: 2.5rem 0 3.5rem;
+  }
+
+  .contacts-page .card-body {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .contacts-header {
+    text-align: left;
+  }
+
+  .contacts-subtitle {
+    margin: 0;
+  }
+
+  .contacts-page .card-body {
+    padding: 1.75rem;
+  }
+
+  .contacts-actions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .contacts-actions .btn {
+    width: 48%;
+    justify-content: center;
+  }
+}

--- a/src/pages/ContactsPage.jsx
+++ b/src/pages/ContactsPage.jsx
@@ -1,5 +1,6 @@
 // src/pages/ContactsPage.jsx
 import React, { useState } from "react";
+import "./ContactsPage.css";
 
 const initialContacts = [
   {
@@ -64,10 +65,10 @@ function ContactForm({ formData, isEditing, onChange, onSubmit, onCancel }) {
   return (
     <div className="card shadow-sm">
       <div className="card-body">
-        <h2 className="h5 mb-4">
+        <h2 className="contacts-section-title mb-4">
           {isEditing ? "Editar contacto" : "Agregar nuevo contacto"}
         </h2>
-        <form className="row g-3" onSubmit={onSubmit}>
+        <form className="row g-3 contacts-form" onSubmit={onSubmit}>
           <div className="col-md-6">
             <label htmlFor="name" className="form-label">
               Nombre
@@ -147,13 +148,13 @@ function ContactForm({ formData, isEditing, onChange, onSubmit, onCancel }) {
             {isEditing && (
               <button
                 type="button"
-                className="btn btn-outline-secondary"
+                className="btn btn-outline-secondary contacts-cancel"
                 onClick={onCancel}
               >
                 Cancelar
               </button>
             )}
-            <button type="submit" className="btn btn-success">
+            <button type="submit" className="btn btn-save">
               {isEditing ? "Actualizar contacto" : "Guardar contacto"}
             </button>
           </div>
@@ -167,9 +168,9 @@ function ContactsTable({ contacts, onEdit, onDelete }) {
   return (
     <div className="card shadow-sm">
       <div className="card-body">
-        <h2 className="h5 mb-4">Contactos registrados</h2>
+        <h2 className="contacts-section-title mb-4">Contactos registrados</h2>
         <div className="table-responsive">
-          <table className="table table-hover align-middle">
+          <table className="table align-middle contacts-table">
             <thead className="table-light">
               <tr>
                 <th scope="col">Nombre</th>
@@ -194,7 +195,7 @@ function ContactsTable({ contacts, onEdit, onDelete }) {
                   <tr key={`${contact.email}-${index}`}>
                     <td className="fw-semibold">{contact.name}</td>
                     <td>
-                      <span className="badge text-bg-primary-subtle text-primary-emphasis">
+                      <span className="contacts-team-badge">
                         {contact.team}
                       </span>
                     </td>
@@ -202,7 +203,7 @@ function ContactsTable({ contacts, onEdit, onDelete }) {
                     <td>
                       <a
                         href={`mailto:${contact.email}`}
-                        className="link-primary text-decoration-none"
+                        className="contact-email"
                       >
                         {contact.email}
                       </a>
@@ -212,23 +213,23 @@ function ContactsTable({ contacts, onEdit, onDelete }) {
                         href={`https://wa.me/${contact.cellphone}`}
                         target="_blank"
                         rel="noreferrer"
-                        className="link-success fw-semibold text-decoration-none"
+                        className="contact-whatsapp"
                       >
                         {formatDisplayPhone(contact.cellphone)}
                       </a>
                     </td>
                     <td className="text-end">
-                      <div className="btn-group btn-group-sm" role="group">
+                      <div className="d-flex justify-content-end contacts-actions" role="group">
                         <button
                           type="button"
-                          className="btn btn-outline-primary"
+                          className="btn btn-edit"
                           onClick={() => onEdit(index)}
                         >
                           Editar
                         </button>
                         <button
                           type="button"
-                          className="btn btn-outline-danger"
+                          className="btn btn-delete"
                           onClick={() => onDelete(index)}
                         >
                           Eliminar
@@ -322,30 +323,32 @@ export default function ContactsPage() {
   };
 
   return (
-    <div className="container py-4">
-      <div className="mb-4">
-        <h1 className="display-6 fw-semibold">Contactos de Team Leads</h1>
-        <p className="text-muted mb-0">
-          Administra el directorio de contactos clave de tu organización.
-        </p>
-      </div>
-
-      <div className="row g-4">
-        <div className="col-12 col-xl-5">
-          <ContactForm
-            formData={formData}
-            isEditing={isEditing}
-            onChange={handleChange}
-            onSubmit={handleSubmit}
-            onCancel={resetForm}
-          />
+    <div className="contacts-page">
+      <div className="container contacts-container">
+        <div className="contacts-header">
+          <h1 className="contacts-title fw-semibold">Contactos de Team Leads</h1>
+          <p className="contacts-subtitle mb-0">
+            Administra el directorio de contactos clave de tu organización.
+          </p>
         </div>
-        <div className="col-12 col-xl-7">
-          <ContactsTable
-            contacts={contacts}
-            onEdit={handleEdit}
-            onDelete={handleDelete}
-          />
+
+        <div className="row g-4 contacts-content-row">
+          <div className="col-12 col-xl-5 contacts-column">
+            <ContactForm
+              formData={formData}
+              isEditing={isEditing}
+              onChange={handleChange}
+              onSubmit={handleSubmit}
+              onCancel={resetForm}
+            />
+          </div>
+          <div className="col-12 col-xl-7 contacts-column">
+            <ContactsTable
+              contacts={contacts}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create a dedicated stylesheet to recreate the provided contact directory look and feel
- update the contacts page markup with presentation classes while preserving its existing CRUD logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c859d79cfc83318efbbae8096ec16f