### PR TITLE
Reorder contacts layout for better responsiveness

### DIFF
--- a/src/pages/ContactsPage.css
+++ b/src/pages/ContactsPage.css
@@ -26,16 +26,31 @@
   margin: 0 auto;
 }
 
-.contacts-content-row {
-  align-items: stretch;
+.contacts-content {
+  display: grid;
+  gap: 2.5rem;
 }
 
-.contacts-column {
+.contacts-panel {
   display: flex;
+  align-items: stretch;
+  min-width: 0;
 }
 
-.contacts-column .card {
+.contacts-panel .card {
   width: 100%;
+}
+
+@media (min-width: 992px) {
+  .contacts-content {
+    gap: 3rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .contacts-content {
+    gap: 2rem;
+  }
 }
 
 .contacts-page .card {
@@ -273,5 +288,29 @@
   .contacts-actions .btn {
     width: 48%;
     justify-content: center;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .contacts-content {
+    gap: 1.5rem;
+  }
+
+  .contacts-page .card-body {
+    padding: 1.5rem;
+  }
+
+  .contacts-table thead th,
+  .contacts-table tbody td {
+    font-size: 0.875rem;
+    padding: 0.65rem 0.9rem;
+  }
+
+  .contacts-actions {
+    gap: 0.5rem;
+  }
+
+  .contacts-actions .btn {
+    width: 100%;
   }
 }

--- a/src/pages/ContactsPage.jsx
+++ b/src/pages/ContactsPage.jsx
@@ -332,8 +332,11 @@ export default function ContactsPage() {
           </p>
         </div>
 
-        <div className="row g-4 contacts-content-row">
-          <div className="col-12 col-xl-5 contacts-column">
+        <div className="contacts-content">
+          <section
+            className="contacts-panel contacts-panel--form"
+            aria-label="Formulario para agregar o editar contactos"
+          >
             <ContactForm
               formData={formData}
               isEditing={isEditing}
@@ -341,14 +344,17 @@ export default function ContactsPage() {
               onSubmit={handleSubmit}
               onCancel={resetForm}
             />
-          </div>
-          <div className="col-12 col-xl-7 contacts-column">
+          </section>
+          <section
+            className="contacts-panel contacts-panel--list"
+            aria-label="Listado de contactos registrados"
+          >
             <ContactsTable
               contacts={contacts}
               onEdit={handleEdit}
               onDelete={handleDelete}
             />
-          </div>
+          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- rework the contacts page layout to stack the form above the contacts table so the listing can use the full width
- introduce semantic section wrappers for the form and table and add accessibility labels
- update contacts page styles with grid-based stacking and responsive spacing so the table and actions adapt better on small screens

## Testing
- npm run lint
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c85ce4903c8331b8007700c0cefe8e