### PR TITLE
Add contact search field to contacts page

### DIFF
--- a/src/pages/ContactsPage.css
+++ b/src/pages/ContactsPage.css
@@ -314,3 +314,71 @@
     width: 100%;
   }
 }
+
+.contacts-list-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.contacts-list-header .contacts-section-title {
+  margin-bottom: 0;
+}
+
+.contacts-search {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  margin: 0;
+}
+
+.contacts-search-input {
+  flex: 1;
+}
+
+.contacts-search-button {
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  color: #ffffff;
+  font-weight: 600;
+  padding: 0.55rem 1.45rem;
+  box-shadow: 0 18px 35px -24px rgba(37, 99, 235, 0.85);
+  transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.contacts-search-button:hover,
+.contacts-search-button:focus {
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 24px 42px -26px rgba(37, 99, 235, 0.9);
+  filter: brightness(1.05);
+}
+
+.contacts-search-button:active {
+  transform: translateY(0);
+}
+
+@media (min-width: 768px) {
+  .contacts-list-header {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .contacts-search {
+    max-width: 420px;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .contacts-search {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .contacts-search-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add an accent-insensitive name search input that filters contacts in the list card
- keep edit/delete actions working on filtered rows and show a message when no matches are found
- style the search controls so they align with the existing contacts layout across breakpoints

## Testing
- npm run lint
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c8621e9978833181e960baedaa1b95